### PR TITLE
Reconciling Project Lifecyce with io.js WGs and future projects

### DIFF
--- a/governance-proposal/TSC-Project-Lifecycle.md
+++ b/governance-proposal/TSC-Project-Lifecycle.md
@@ -4,7 +4,7 @@
 
 ## Project Definition
 
-A *project* is an autonomous group collaborating to achieve a set of responsibilities.
+A *project* is an autonomous group collaborating to fulfill a set of responsibilities.
 
 A project could be a working group collaborating with multiple groups both inside and outside the foundation but with no specific code base of its own to be released. A project could also be a traditional module or set of modules released regularly. This document draws no distinction between what are traditionally referred to as "working groups" or "committees" and traditional software projects.
 

--- a/governance-proposal/TSC-Project-Lifecycle.md
+++ b/governance-proposal/TSC-Project-Lifecycle.md
@@ -4,33 +4,36 @@
 
 ## Project Definition
 
-A *project* is an autonomous group collaborating to fulfill a set of responsibilities.
+The Node.js Foundation hosts several "Top Level Projects." These projects are autonomous from each other and governed by their own TSC (Technical Steering Committee) and chartered by the Node.js Foundation's Board of Directors.
 
-A project could be a working group collaborating with multiple groups both inside and outside the foundation but with no specific code base of its own to be released. A project could also be a traditional module or set of modules released regularly. This document draws no distinction between what are traditionally referred to as "working groups" or "committees" and traditional software projects.
+Projects are free to create "Working Groups" which are autonomus groups collaborating to fulfill a set of responsibilities. Working Groups are eventually chartered by the TSC.
+
+```
+Board
+  |
+  |-- Project A (Chartered By Board)
+  |       |
+  |       |-- TSC
+  |       |-- Working Group (Chartered By Project TSC)
+  |
+  |-- Project B (Chartered By Board)
+          |
+          |-- TSC
+          |-- Working Group (Chartered By Project TSC)  
+```
 
 ## Lifecycle
 
-Node.js Foundation’s technical Projects shall follow a lifecycle described in this Project Lifecycle document.  
+The Foundation shall encourage new Projects and innovation in the community. New Projects enter the Node.js Foundation through a Proposal. The proposal should include their TSC Charter and Development Policy.
 
-The TSC shall encourage new Projects and innovation in the technical community. New Projects enter the Node.js technical community through a Proposal to the TSC or through the Bootstrap process.
+Project should have some prior history and be considered mature and contain a wide contributorship before entering submitting a proposal to enter the foundation.
 
-## Bootstrap and Proposal
+## Project Life-Cycle
 
-Before a project is chartered it must first incubate in some manner.
-
-If a project needs to start *in* the foundation members are free to create a repository and begin regular meetings using the free tools available to all project members. During this period the project is unchartered and in the "Bootstrap" cycle and is not entitled to any financial or legal resources of the foundation and can be closed at any time by the TSC. Once the project matures and is ready to write a proposal that is sent to the TSC for approval and the project moves to the "Mature" phase once approved.
-
-It is also common for projects to incubate and mature outside the foundation. These projects do not need to incubate within the foundation itself and instead should write a proposal for the TSC to approve and move directly to the "Mature" pahse.
-
-Projects shall change state following TSC reviews. Projects typically change states independently from each other, but can cooperate closely and leverage each other’s results. Projects graduate from Proposal-state, through Incubation-state and Mature-state to Core-state. Archived–state is a Project state reserved for those Projects no longer being actively developed or used by the community.
-
-| Project state |	Description |
+| State |	Description |
 | ------------- | ----------- |
-| Incubation | Project has not been approved and is unchartered. Project does not formally exist yet, may not have real resources (yet), but is being worked on by the community. |
-| Proposal | Project proposal is posted and under review. |
-| Mature | Project is fully functioning but is not a required component of the platform.|
-| Core | Project is a required component of the Node.js platform.|
-| Archived | Project has been recognized as no longer being actively used or developed. This could be for a variety of reasons, e.g. project successfully accomplished its goals but is no longer used, project failed, etc., and has been archived as it's no longer a going concern.|
+| `null` | Prior to being considered for the foundation the project should mature elsewhere and achieve a wide contributorship. |
+| Accepted | Project is accepted into the foundation. It is entitled to the resources contained in its proposal and can form Working Groups. |
 
 ### Project state transitions
 
@@ -40,43 +43,46 @@ Projects shall change state following TSC reviews. Projects typically change sta
 | Mature | Core | Core Review |
 | Proposal, Bootstrap, Mature, Core | Archived | Archive Review |
 
+## Working Group Life-Cycle
+
+Before a WG is chartered it must first incubate in some manner.
+
+If a WG needs to start *in* the project members are free to create a repository and begin regular meetings using the free tools available to all project members. During this period the WG is unchartered and in the "Bootstrap" cycle and is not entitled to any financial or legal resources of the foundation and can be closed at any time by the TSC. Once the WG matures it should write a proposal for the TSC to approval so the WG can move to the "Mature" phase once approved.
+
+It is also common for Working Groups to incubate and mature outside the project. These Working Groups do not need to incubate within the project itself and instead should write a proposal for the TSC to approve and move directly to the "Mature" phase.
+
+Working Groups shall change state following TSC reviews. WGs typically change states independently from each other, but can cooperate closely and leverage each other’s results. Projects graduate from Proposal-state, to Mature-state and finally to Core-state. Archived–state is a Project state reserved for those Projects no longer being actively developed or used by the community.
+
+| State |	Description |
+| ------------- | ----------- |
+| Incubation | WG has not been approved and is unchartered. Project does not formally exist yet, may not have real resources (yet), but is being worked on by the community. |
+| Proposal | WG proposal is posted and under review. |
+| Mature | WG is fully functioning but is not a required component of the platform.|
+| Core | WG is a required component of the Node.js platform.|
+| Archived | WG has been recognized as no longer being actively used or developed. This could be for a variety of reasons, e.g. WG successfully accomplished its goals but is no longer used, project failed, etc., and has been archived as it's no longer a going concern.|
+
+### WG state transitions
+
+| From State | To State | Review |
+| ---------- | -------- | ------ |
+| Proposal | Mature | Proposal Review |
+| Mature | Core | Core Review |
+| Proposal, Bootstrap, Mature, Core | Archived | Archive Review |
+
 ## Reviews
 
-### Proposal Review
-* Proposal posted for two weeks, evaluated on metrics of:
- * Name is okay (e.g. no use of a trademark)
- * Project contact name, email and/or repo.
- * Description is complete
- * Scope and project plan is well defined
- * Resources are well defined
- * Initial members named
- * Initial contributors named
- * Meets Foundation’s policies (e.g. IP Policy)
- * Proposal has been socialized with potentially interested or affected existing Projects
- * The Project demonstrates stable output (e.g. code base, documents, tests, meetings, releases)
- * Active community working on the Project
- * History of successful
-* TSC review
- * Working and stable community and output.
- * Confirmed acceptance and successful integration of contributions/code to partner/upstream projects when applicable.
- * Testing/integration environment defined and mature, tests and integration run successfully when applicable.
- * Well defined project documentation: contribution, governance, membership, and conduct policies in place.
+### Project Proposal Review
 
-### Core Review
- * Core-state proposal posted for two weeks
-   * Project is shown to be a viable and necessary subsystem or component of the Node.js Platform.
-   * Project build and test scripts have been created to work with the rest of the Node.js Platform.
-   * Project shown to not break continuous development and integration environment.
- * TSC review metrics
-   * Core review assesses projects based on the metrics of the graduation review and the necessity of the project relative to the codebase and user requirements.
-   * In addition the project is required to have confirmed longevity (e.g. the project has been active for at least one year, participates in release activities, and has release plans outlined to stay active for at least another year).
+TODO
 
-### Termination Review
-* Termination proposal posted for two weeks
- * States reason for project termination being sought
-   * Termination proposal to include acceptable triggers for termination
-   * (e.g. protracted idleness, or request by the project)
- * Estimates impact on other projects and how to mitigate
- * Impact and possible breakage to APIs or builds
- * Location identified and links created for archived project
-* If Archival is not approved, the Project remains in its pre-reviewed state
+### Working Group Proposal Review
+
+TODO
+
+### WG Core Review
+
+TODO
+
+### WG Termination Review
+
+TODO

--- a/governance-proposal/TSC-Project-Lifecycle.md
+++ b/governance-proposal/TSC-Project-Lifecycle.md
@@ -16,7 +16,7 @@ The TSC shall encourage new Projects and innovation in the technical community. 
 
 ## Bootstrap and Proposal
 
-Before a project is chartered it must first incubate in some manor.
+Before a project is chartered it must first incubate in some manner.
 
 If a project needs to start *in* the foundation members are free to create a repository and begin regular meetings using the free tools available to all project members. During this period the project is unchartered and in the "Bootstrap" cycle and is not entitled to any financial or legal resources of the foundation and can be closed at any time by the TSC. Once the project matures and is ready to write a proposal that is sent to the TSC for approval and the project moves to the "Mature" phase once approved.
 

--- a/governance-proposal/TSC-Project-Lifecycle.md
+++ b/governance-proposal/TSC-Project-Lifecycle.md
@@ -2,70 +2,74 @@
 
 # Node.js Foundation Project Lifecycle
 
+## Project Definition
+
+A *project* is an autonomous group collaborating to achieve a set of responsibilities.
+
+A project could be a working group collaborating with multiple groups both inside and outside the foundation but with no specific code base of its own to be released. A project could also be a traditional module or set of modules released regularly. This document draws no distinction between what are traditionally referred to as "working groups" or "committees" and traditional software projects.
+
+## Lifecycle
+
 Node.js Foundation’s technical Projects shall follow a lifecycle described in this Project Lifecycle document.  
 
-The TSC shall create, align and coordinate Projects that are ideally developed together, including possibly, the creation of sub-Projects. The TSC shall have the power to reorganize Projects and sub-Projects after sufficient review and discussion with the Projects and community involved.
+The TSC shall encourage new Projects and innovation in the technical community. New Projects enter the Node.js technical community through a Proposal to the TSC or through the Bootstrap process.
 
-The TSC shall encourage new Projects and innovation in the technical community. New Projects enter the Node.js technical community through a Proposal to the TSC and if approved, are granted Incubation-state status.
+## Bootstrap and Proposal
 
-Projects shall change state following TSC reviews. Projects typically change states independently from each other, but can cooperate closely and leverage each other’s results. Projects graduate from Proposal-state, through Incubation-state and Mature-state to Core-state. Archived–state is a Project state reserved for those Projects no longer being actively developed or used by the community.
+Before a project is chartered it must first incubate in some manor.
 
-The TSC shall have the authority to grandfather proposed Projects with a significant history and record to meet the project state descriptions below into a higher order state during the first 12 months after the first TSC meeting.
+If a project needs to start *in* the foundation members are free to create a repository and begin regular meetings using the free tools available to all project members. During this period the project is unchartered and in the "Bootstrap" cycle and is not entitled to any financial or legal resources of the foundation and can be closed at any time by the TSC. Once the project matures and is ready to write a proposal that is sent to the TSC for approval and the project moves to the "Mature" phase once approved.
+
+It is also common for projects to incubate and mature outside the foundation. These projects do not need to incubate within the foundation itself and instead should write a proposal for the TSC to approve and move directly to the "Mature" pahse.
+
+Projects shall change state following TSC reviews. Projects typically change states independently from each other, but can cooperate closely and leverage each other’s results. Projects graduate from Proposal-state, through Incubation-state and Mature-state to Core-state. Archived–state is a Project state reserved for those Projects no longer being actively developed or used by the community.
 
 | Project state |	Description |
 | ------------- | ----------- |
-| Proposal | Project does not formally exist yet, may not have real resources (yet), but is being worked on by the community to submit a formal proposal to the TSC. |
-| Incubation | Project has been approved by the TSC, has resources, but is recognized to be nascent. |
-| Mature | Project is fully functioning and stable, has achieved successful releases, has a Project Lead, but is not a required component of the platform.|
+| Incubation | Project has not been approved and is unchartered. Project does not formally exist yet, may not have real resources (yet), but is being worked on by the community. |
+| Proposal | Project proposal is posted and under review. |
+| Mature | Project is fully functioning but is not a required component of the platform.|
 | Core | Project is a required component of the Node.js platform.|
 | Archived | Project has been recognized as no longer being actively used or developed. This could be for a variety of reasons, e.g. project successfully accomplished its goals but is no longer used, project failed, etc., and has been archived as it's no longer a going concern.|
- 
+
 ### Project state transitions
 
 | From State | To State | Review |
 | ---------- | -------- | ------ |
-| `null` | Proposal | n/a |
-| Proposal | Incubation | Creation Review |
-| Incubation | Mature | Graduation Review |
+| Proposal | Mature | Proposal Review |
 | Mature | Core | Core Review |
-| Proposal, Incubation, Mature, Core | Archived | Archive Review |
+| Proposal, Bootstrap, Mature, Core | Archived | Archive Review |
 
 ## Reviews
 
-### Creation Review
-* Proposal posted for two weeks, evaluated on metrics of:
+### Proposal Review
+* Proposal posted for two weeks, evaluated on metrics of:
  * Name is okay (e.g. no use of a trademark)
- * Project contact name and email
+ * Project contact name, email and/or repo.
  * Description is complete
  * Scope and project plan is well defined
- * Resources are committed
- * Initial Committers named
- * Contributors have been identified
+ * Resources are well defined
+ * Initial members named
+ * Initial contributors named
  * Meets Foundation’s policies (e.g. IP Policy)
  * Proposal has been socialized with potentially interested or affected existing Projects
- * Proposal email has been sent to the TSC mailing list
-* Review by TSC: Confirm that the proposal is complete and the above listed requirements have been sufficiently met.
-
-### Graduation Review
-* Graduation proposal posted for two weeks:
- * The Project demonstrates stable output (code base, documents, tests)
+ * The Project demonstrates stable output (e.g. code base, documents, tests, meetings, releases)
  * Active community working on the Project
- * History of successful, consistent releases in accordance with the release process
+ * History of successful
 * TSC review
- * Working and stable code base exists
- * Active community exists
- * Project has demonstrated a history of releases following the release process and cadence
- * Confirmed acceptance and successful integration of contributions/code to partner/upstream projects. 
- * Testing/integration environment defined and mature, tests and integration run successfully
- * Detailed documentation available documenting the code
+ * Working and stable community and output.
+ * Confirmed acceptance and successful integration of contributions/code to partner/upstream projects when applicable.
+ * Testing/integration environment defined and mature, tests and integration run successfully when applicable.
+ * Well defined project documentation: contribution, governance, membership, and conduct policies in place.
+
 ### Core Review
  * Core-state proposal posted for two weeks
-   * Project is shown to be viable, necessary or broadly useful module, subsystem or component of Node.js
-   * Project build and test scripts have been created to work with the rest of Platform build
-   * Project shown to not break continuous development and integration environment 
+   * Project is shown to be a viable and necessary subsystem or component of the Node.js Platform.
+   * Project build and test scripts have been created to work with the rest of the Node.js Platform.
+   * Project shown to not break continuous development and integration environment.
  * TSC review metrics
-   * Core review assesses projects based on the metrics of the graduation review and the necessity of the project relative to the codebase and user requirements.
-   * In addition the project is required to have confirmed longevity (e.g. the project has been active for at least one year, participates in release activities, and has release plans outlined to stay active for at least another year). 
+   * Core review assesses projects based on the metrics of the graduation review and the necessity of the project relative to the codebase and user requirements.
+   * In addition the project is required to have confirmed longevity (e.g. the project has been active for at least one year, participates in release activities, and has release plans outlined to stay active for at least another year).
 
 ### Termination Review
 * Termination proposal posted for two weeks

--- a/governance-proposal/WG-Merger.md
+++ b/governance-proposal/WG-Merger.md
@@ -1,0 +1,50 @@
+This document describes the existing io.js and node.js working groups and resources, how they would merge, and at which point in the Project Lifecycle they would be.
+
+| Group | io.js | node.js | Lifecycle |
+| ----- | ----- | ------- | --------- |
+| Build | [build](https://github.com/iojs/build) | ? | Core |
+| Docker | [docker](https://github.com/iojs/build) | [docker-node](https://github.com/joyent/docker-node) | Mature |
+| Website | [website](https://github.com/iojs/website) | [node-website](https://github.com/joyent/node-website) | Mature |
+| Evangelism | [evangelism](https://github.com/iojs/evangelism) | none | Mature |
+| Hardware | [hardware](https://github.com/iojs/hardware) | none | Incubation |
+| Streams | [streams](https://github.com/iojs/readable-streams) | none | Core |
+| Tracing | [tracing](https://github.com/iojs/tracing) | none | Core |
+
+Additionally, there are the io.js international communities. I've used the data @kosamari has been keeping to identify activity and assign a lifecycle.
+
+| Name | Language | Lifecycle |
+| ---- | -------- | --------- |
+| [iojs-ar](https://github.com/iojs/iojs-ar) | Arabic | Incubation |
+| [iojs-bg](https://github.com/iojs/iojs-bg) | Bulgarian | Incubation |
+| [iobs-bn](https://github.com/iojs/iojs-bn) | Bengali | Incubation |
+| [iojs-cn](https://github.com/iojs/iojs-cn) | Chinese | Mature |
+| [iojs-cs](https://github.com/iojs/iojs-cs) | Czech | Incubation |
+| [iojs-da](https://github.com/iojs/iojs-da) | Danish | Mature |
+| [iojs-de](https://github.com/iojs/iojs-de) | German | Mature |
+| [iojs-el](https://github.com/iojs/iojs-el) | Greek | Mature |
+| [iojs-es](https://github.com/iojs/iojs-es) | Spanish | Mature |
+| [iojs-fa](https://github.com/iojs/iojs-fa) | Persian | Incubation |
+| [iojs-fi](https://github.com/iojs/iojs-fi) | Finnish | Mature |
+| [iojs-fr](https://github.com/iojs/iojs-fr) | French | Mature |
+| [iojs-he](https://github.com/iojs/iojs-he) | Hebrew | Mature |
+| [iojs-hi](https://github.com/iojs/iojs-hi) | Hindi | Mature |
+| [iojs-hu](https://github.com/iojs/iojs-hu) | Hungarian | Mature |
+| [iojs-id](https://github.com/iojs/iojs-id) | Indonesian | Mature |
+| [iojs-it](https://github.com/iojs/iojs-it) | Italian | Mature |
+| [iojs-ja](https://github.com/iojs/iojs-ja) | Japanese | Mature |
+| [iojs-ka](https://github.com/iojs/iojs-ka) | Georgian | Mature |
+| [iojs-ko](https://github.com/iojs/iojs-ko) | Korean | Mature |
+| [ioja-mk](https://github.com/iojs/iojs-mk) | Macedonian | Incubation |
+| [iojs-ms](https://github.com/iojs/iojs-ms) | Malay | Incubation |
+| [iojs-nl](https://github.com/iojs/iojs-nl) | Dutch | Mature |
+| [iohs-no](https://github.com/iojs/iojs-no) | Norwegian | Mature |
+| [iohs-pl](https://github.com/iojs/iojs-pl) | Polish | Incubation |
+| [iojs-pt](https://github.com/iojs/iojs-pt) | Portuguese | Mature |
+| [iojs-ru](https://github.com/iojs/iojs-ru) | Russian | Mature |
+| [iojs-ro](https://github.com/iojs/iojs-ro) | Romanian | Incubation |
+| [iojs-sv](https://github.com/iojs/iojs-sv) | Swedish | Incubation |
+| [iojs-ta](https://github.com/iojs/iojs-ta) | Tanuk | Incubation |
+| [iojs-tr](https://github.com/iojs/iojs-tr) | Turkish | Mature |
+| [iojs-tw](https://github.com/iojs/iojs-tw) | Taiwanese | Mature |
+| [iojs-uk](https://github.com/iojs/iojs-uk) | Ukrainian | Mature |
+| [iojs-vi](https://github.com/iojs/iojs-vi) | Vietnamese | Mature |

--- a/governance-proposal/WG-Merger.md
+++ b/governance-proposal/WG-Merger.md
@@ -27,12 +27,12 @@ Additionally, there are the io.js international communities. I've used the data 
 | [iojs-fi](https://github.com/iojs/iojs-fi) | Finnish | Mature |
 | [iojs-fr](https://github.com/iojs/iojs-fr) | French | Mature |
 | [iojs-he](https://github.com/iojs/iojs-he) | Hebrew | Mature |
-| [iojs-hi](https://github.com/iojs/iojs-hi) | Hindi | Mature |
-| [iojs-hu](https://github.com/iojs/iojs-hu) | Hungarian | Mature |
+| [iojs-hi](https://github.com/iojs/iojs-hi) | Hindi | Incubation |
+| [iojs-hu](https://github.com/iojs/iojs-hu) | Hungarian | Incubation |
 | [iojs-id](https://github.com/iojs/iojs-id) | Indonesian | Mature |
 | [iojs-it](https://github.com/iojs/iojs-it) | Italian | Mature |
 | [iojs-ja](https://github.com/iojs/iojs-ja) | Japanese | Mature |
-| [iojs-ka](https://github.com/iojs/iojs-ka) | Georgian | Mature |
+| [iojs-ka](https://github.com/iojs/iojs-ka) | Georgian | Incubation |
 | [iojs-ko](https://github.com/iojs/iojs-ko) | Korean | Mature |
 | [ioja-mk](https://github.com/iojs/iojs-mk) | Macedonian | Incubation |
 | [iojs-ms](https://github.com/iojs/iojs-ms) | Malay | Incubation |


### PR DESCRIPTION
This is my first attempt at reconciling what we've been doing in io.js Working Groups with the standard LF Project Lifecycle. I've tried to keep some of the constraints in place to project the foundation from spending resources while still allowing the more liberal creation and bootstrapping we've had success with in io.js Working Groups.

The biggest change is to the incubation and proposal phases. Basically, "Incubation" has two paths, either "bootstrapped" (inside the foundation) or a project matures outside the foundation to a significant point and then would like to join. In both cases incubation happens before a proposal or charter is defined. This allows us to experiment and create projects with less barriers but keep them at arms length (provisional status can be shut down at any time, no monetary or legal resources committed) and allow them to mature before we write the charter.

In the io.js working groups we've found that it's best to remove barriers to people forming groups and getting work done and that it's much better to have groups write a proposal/charter after they've been doing work successfully.

This change to the incubation phase actually reduced the number of levels and reviews, simplifying the process quite a bit. There are some other smaller edits and changes in the review processes that are trying to bring it more in line with the working groups we have in io.js which aren't strictly code projects with their own releases.
