### PR TITLE
Include Issac Roth in the attendee list.

### DIFF
--- a/meetings/2015-04-06/minutes.md
+++ b/meetings/2015-04-06/minutes.md
@@ -13,7 +13,7 @@ Danese Cooper (DC)
 Todd Moore (TM)  
 Gianugo Rabellino (GR)  
 Trevor Norris (TN)  
-
+Issac Roth (IR)  
 
 
 ## Recap


### PR DESCRIPTION
His name was inadvertently omitted.